### PR TITLE
feat: document deletion with retrieval ground truth validation

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -24,6 +24,7 @@ declare module 'vue' {
     CardTitle: typeof import('./src/components/ui/card/CardTitle.vue')['default']
     Checkbox: typeof import('./src/components/ui/checkbox/Checkbox.vue')['default']
     ConnectionDialog: typeof import('./src/components/connection/ConnectionDialog.vue')['default']
+    DeleteDocumentDialog: typeof import('./src/components/documents/DeleteDocumentDialog.vue')['default']
     Dialog: typeof import('./src/components/ui/dialog/Dialog.vue')['default']
     DialogClose: typeof import('./src/components/ui/dialog/DialogClose.vue')['default']
     DialogContent: typeof import('./src/components/ui/dialog/DialogContent.vue')['default']

--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -1,7 +1,8 @@
 use tauri::State;
 
 use crate::db::{
-    Document, DocumentWithPages, File, FileWithDocuments, ImageChunkInfo, PageInfo, PageWithChunks,
+    Document, DocumentDeletionCheck, DocumentWithPages, File, FileWithDocuments, ImageChunkInfo,
+    PageInfo, PageWithChunks, Query,
 };
 use crate::error::{AppError, Result};
 use crate::state::AppState;
@@ -229,4 +230,146 @@ pub async fn list_documents(state: State<'_, AppState>) -> Result<Vec<Document>>
     .await?;
 
     Ok(documents)
+}
+
+/// Check whether a document can be safely deleted by looking for
+/// queries that reference its chunks as retrieval ground truth evidence.
+#[tauri::command]
+pub async fn check_document_deletable(
+    document_id: i64,
+    state: State<'_, AppState>,
+) -> Result<DocumentDeletionCheck> {
+    let pool = state.get_pool().await.ok_or(AppError::NotConnected)?;
+
+    let blocking_queries = sqlx::query_as::<_, Query>(
+        r#"
+        SELECT DISTINCT q.id, q.contents, q.query_to_llm, q.generation_gt
+        FROM query q
+        JOIN retrieval_relation rr ON rr.query_id = q.id
+        JOIN image_chunk ic ON ic.id = rr.image_chunk_id
+        JOIN page p ON p.id = ic.parent_page
+        WHERE p.document_id = $1
+        ORDER BY q.id
+        "#,
+    )
+    .bind(document_id)
+    .fetch_all(&pool)
+    .await?;
+
+    Ok(DocumentDeletionCheck {
+        deletable: blocking_queries.is_empty(),
+        blocking_queries,
+    })
+}
+
+/// Delete a document and all its dependent data (pages, chunks, etc.)
+/// Fails if any queries reference this document's chunks as evidence.
+#[tauri::command]
+pub async fn delete_document(document_id: i64, state: State<'_, AppState>) -> Result<bool> {
+    let pool = state.get_pool().await.ok_or(AppError::NotConnected)?;
+
+    // Safety re-check: ensure no retrieval relations reference this document's chunks
+    let blocking_count: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*)
+        FROM retrieval_relation rr
+        JOIN image_chunk ic ON ic.id = rr.image_chunk_id
+        JOIN page p ON p.id = ic.parent_page
+        WHERE p.document_id = $1
+        "#,
+    )
+    .bind(document_id)
+    .fetch_one(&pool)
+    .await?;
+
+    if blocking_count.0 > 0 {
+        return Err(AppError::Custom(format!(
+            "Cannot delete document {}: {} retrieval relation(s) still reference its chunks",
+            document_id, blocking_count.0
+        )));
+    }
+
+    // Fetch document to get file FK
+    let document = sqlx::query_as::<_, Document>(
+        r#"
+        SELECT id, path, filename, author, title, doc_metadata
+        FROM document
+        WHERE id = $1
+        "#,
+    )
+    .bind(document_id)
+    .fetch_optional(&pool)
+    .await?
+    .ok_or_else(|| AppError::NotFound(format!("Document {} not found", document_id)))?;
+
+    // Collect page IDs for this document
+    let page_ids: Vec<i64> = sqlx::query_scalar(
+        r#"SELECT id FROM page WHERE document_id = $1"#,
+    )
+    .bind(document_id)
+    .fetch_all(&pool)
+    .await?;
+
+    // Begin transaction — delete in FK-safe order
+    let mut tx = pool.begin().await?;
+
+    if !page_ids.is_empty() {
+        // Delete image_chunk_retrieved_result for chunks belonging to this document's pages
+        sqlx::query(
+            r#"
+            DELETE FROM image_chunk_retrieved_result
+            WHERE image_chunk_id IN (
+                SELECT id FROM image_chunk WHERE parent_page = ANY($1)
+            )
+            "#,
+        )
+        .bind(&page_ids)
+        .execute(&mut *tx)
+        .await?;
+
+        // Delete image_chunk rows
+        sqlx::query(r#"DELETE FROM image_chunk WHERE parent_page = ANY($1)"#)
+            .bind(&page_ids)
+            .execute(&mut *tx)
+            .await?;
+
+        // Delete page_chunk_relation rows
+        sqlx::query(r#"DELETE FROM page_chunk_relation WHERE page_id = ANY($1)"#)
+            .bind(&page_ids)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    // Delete pages
+    sqlx::query(r#"DELETE FROM page WHERE document_id = $1"#)
+        .bind(document_id)
+        .execute(&mut *tx)
+        .await?;
+
+    // Delete document
+    sqlx::query(r#"DELETE FROM document WHERE id = $1"#)
+        .bind(document_id)
+        .execute(&mut *tx)
+        .await?;
+
+    // Clean up orphaned file record if no other documents reference it
+    if let Some(file_id) = document.path {
+        let other_docs: (i64,) = sqlx::query_as(
+            r#"SELECT COUNT(*) FROM document WHERE path = $1"#,
+        )
+        .bind(file_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        if other_docs.0 == 0 {
+            sqlx::query(r#"DELETE FROM file WHERE id = $1"#)
+                .bind(file_id)
+                .execute(&mut *tx)
+                .await?;
+        }
+    }
+
+    tx.commit().await?;
+
+    Ok(true)
 }

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -178,3 +178,10 @@ pub struct UpdateScoreRequest {
     pub group_order: i32,
     pub score: i32,
 }
+
+/// Result of checking whether a document can be safely deleted
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentDeletionCheck {
+    pub deletable: bool,
+    pub blocking_queries: Vec<Query>,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,8 @@ pub fn run() {
             commands::get_page_chunks,
             commands::get_file_path,
             commands::get_document_page_count,
+            commands::check_document_deletable,
+            commands::delete_document,
             // Image commands
             commands::get_source_file_url,
             commands::get_page_source_urls,

--- a/src/components/documents/DeleteDocumentDialog.vue
+++ b/src/components/documents/DeleteDocumentDialog.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { useDocumentsStore, useUiStore, type DocumentDeletionCheck } from '@/stores'
+
+const documentsStore = useDocumentsStore()
+const uiStore = useUiStore()
+
+const isChecking = ref(false)
+const checkResult = ref<DocumentDeletionCheck | null>(null)
+const checkError = ref<string | null>(null)
+
+watch(
+  () => uiStore.isDeleteDocumentDialogOpen,
+  async (isOpen) => {
+    if (isOpen && uiStore.deleteDocumentTarget) {
+      isChecking.value = true
+      checkResult.value = null
+      checkError.value = null
+      try {
+        checkResult.value = await documentsStore.checkDocumentDeletable(
+          uiStore.deleteDocumentTarget.id,
+        )
+      } catch (err) {
+        checkError.value = err instanceof Error ? err.message : String(err)
+      } finally {
+        isChecking.value = false
+      }
+    } else {
+      checkResult.value = null
+      checkError.value = null
+    }
+  },
+)
+
+async function handleDelete() {
+  if (!uiStore.deleteDocumentTarget) return
+  const success = await documentsStore.deleteDocument(uiStore.deleteDocumentTarget.id)
+  if (success) {
+    uiStore.closeDeleteDocumentDialog()
+  }
+}
+</script>
+
+<template>
+  <Dialog v-model:open="uiStore.isDeleteDocumentDialogOpen">
+    <DialogContent class="bg-gray-800 border-gray-700 text-gray-100 sm:max-w-md">
+      <!-- Loading State -->
+      <template v-if="isChecking">
+        <DialogHeader>
+          <DialogTitle>Checking Document</DialogTitle>
+          <DialogDescription class="text-gray-400">
+            Verifying whether this document can be safely deleted...
+          </DialogDescription>
+        </DialogHeader>
+        <div class="flex items-center justify-center py-8">
+          <span class="i-mdi-loading animate-spin text-2xl text-gray-400" />
+        </div>
+      </template>
+
+      <!-- Error State -->
+      <template v-else-if="checkError">
+        <DialogHeader>
+          <DialogTitle>Error</DialogTitle>
+          <DialogDescription class="text-gray-400">
+            Failed to check document deletion status.
+          </DialogDescription>
+        </DialogHeader>
+        <div class="rounded-md bg-red-900/50 p-3 text-sm text-red-300">
+          <span class="i-mdi-alert-circle mr-2" />
+          {{ checkError }}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            class="border-gray-600 hover:bg-gray-700"
+            @click="uiStore.closeDeleteDocumentDialog()"
+          >
+            Close
+          </Button>
+        </DialogFooter>
+      </template>
+
+      <!-- Blocked State -->
+      <template v-else-if="checkResult && !checkResult.deletable">
+        <DialogHeader>
+          <DialogTitle class="text-red-400">Cannot Delete</DialogTitle>
+          <DialogDescription class="text-gray-400">
+            "{{ uiStore.deleteDocumentTarget?.title }}" has chunks referenced as retrieval ground
+            truth in {{ checkResult.blocking_queries.length }} query/queries. Remove these
+            references first.
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea class="max-h-60">
+          <div class="space-y-1 pr-3">
+            <div
+              v-for="query in checkResult.blocking_queries"
+              :key="query.id"
+              class="rounded bg-gray-700/50 px-3 py-2 text-sm"
+            >
+              <span class="font-mono text-gray-500">Q{{ query.id }}:</span>
+              <span class="ml-2 text-gray-300">{{ query.contents }}</span>
+            </div>
+          </div>
+        </ScrollArea>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            class="border-gray-600 hover:bg-gray-700"
+            @click="uiStore.closeDeleteDocumentDialog()"
+          >
+            Close
+          </Button>
+        </DialogFooter>
+      </template>
+
+      <!-- Confirm State -->
+      <template v-else-if="checkResult && checkResult.deletable">
+        <DialogHeader>
+          <DialogTitle>Delete Document</DialogTitle>
+          <DialogDescription class="text-gray-400">
+            Are you sure you want to delete "{{ uiStore.deleteDocumentTarget?.title }}"? This will
+            permanently remove the document and all its pages and chunks.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter class="gap-2">
+          <Button
+            variant="outline"
+            class="border-gray-600 hover:bg-gray-700"
+            :disabled="documentsStore.isDeleting"
+            @click="uiStore.closeDeleteDocumentDialog()"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            :disabled="documentsStore.isDeleting"
+            @click="handleDelete"
+          >
+            <span v-if="documentsStore.isDeleting" class="i-mdi-loading animate-spin mr-2" />
+            <span v-else class="i-mdi-delete mr-2" />
+            {{ documentsStore.isDeleting ? 'Deleting...' : 'Delete' }}
+          </Button>
+        </DialogFooter>
+      </template>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/src/components/documents/DocumentSelector.vue
+++ b/src/components/documents/DocumentSelector.vue
@@ -2,6 +2,7 @@
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
+import DeleteDocumentDialog from './DeleteDocumentDialog.vue'
 import { useConnectionStore, useDocumentsStore, useSelectionStore, useUiStore } from '@/stores'
 
 const connectionStore = useConnectionStore()
@@ -16,6 +17,10 @@ async function selectDocument(documentId: number) {
 
 function isDocumentSelected(documentId: number): boolean {
   return documentsStore.currentDocumentInfo?.id === documentId
+}
+
+function handleDeleteClick(doc: { id: number; title: string | null; filename: string | null }) {
+  uiStore.openDeleteDocumentDialog(doc.id, doc.title || doc.filename || 'Untitled')
 }
 
 async function handleRefresh() {
@@ -95,18 +100,31 @@ async function handleRefresh() {
 
         <!-- Document List -->
         <div v-else class="space-y-0.5">
-          <button
+          <div
             v-for="doc in documentsStore.documents"
             :key="doc.id"
-            class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors"
+            class="group flex items-center rounded transition-colors"
             :class="isDocumentSelected(doc.id) ? 'bg-blue-600 text-white' : 'hover:bg-gray-700 text-gray-300'"
-            @click="selectDocument(doc.id)"
           >
-            <span class="i-mdi-file-document-outline" />
-            <span class="flex-1 truncate">{{ doc.title || doc.filename || 'Untitled' }}</span>
-          </button>
+            <button
+              class="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left text-sm"
+              @click="selectDocument(doc.id)"
+            >
+              <span class="i-mdi-file-document-outline shrink-0" />
+              <span class="flex-1 truncate">{{ doc.title || doc.filename || 'Untitled' }}</span>
+            </button>
+            <button
+              class="mr-1 shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:text-red-400 group-hover:opacity-100"
+              title="Delete document"
+              @click.stop="handleDeleteClick(doc)"
+            >
+              <span class="i-mdi-delete-outline text-base" />
+            </button>
+          </div>
         </div>
       </div>
     </ScrollArea>
+
+    <DeleteDocumentDialog />
   </div>
 </template>

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -7,6 +7,7 @@ export {
   type ImageChunkInfo,
   type PageWithChunks,
   type DocumentWithPages,
+  type DocumentDeletionCheck,
 } from './documents'
 export { useSelectionStore, type EvidenceWithScore, type EvidencePageItem } from './selection'
 export {

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -10,6 +10,8 @@ export const useUiStore = defineStore('ui', () => {
   const isConnectionDialogOpen = ref(false)
   const isPreviewModalOpen = ref(false)
   const isIngestDialogOpen = ref(false)
+  const isDeleteDocumentDialogOpen = ref(false)
+  const deleteDocumentTarget = ref<{ id: number; title: string } | null>(null)
   const previewPageId = ref<number | null>(null)
 
   // View settings
@@ -30,6 +32,16 @@ export const useUiStore = defineStore('ui', () => {
 
   function closeIngestDialog() {
     isIngestDialogOpen.value = false
+  }
+
+  function openDeleteDocumentDialog(id: number, title: string) {
+    deleteDocumentTarget.value = { id, title }
+    isDeleteDocumentDialogOpen.value = true
+  }
+
+  function closeDeleteDocumentDialog() {
+    isDeleteDocumentDialogOpen.value = false
+    deleteDocumentTarget.value = null
   }
 
   function openPreview(pageId: number) {
@@ -64,6 +76,8 @@ export const useUiStore = defineStore('ui', () => {
     isConnectionDialogOpen,
     isPreviewModalOpen,
     isIngestDialogOpen,
+    isDeleteDocumentDialogOpen,
+    deleteDocumentTarget,
     previewPageId,
     thumbnailSize,
     showPageNumbers,
@@ -71,6 +85,8 @@ export const useUiStore = defineStore('ui', () => {
     closeConnectionDialog,
     openIngestDialog,
     closeIngestDialog,
+    openDeleteDocumentDialog,
+    closeDeleteDocumentDialog,
     openPreview,
     closePreview,
     setThumbnailSize,


### PR DESCRIPTION
## Summary

- Add `check_document_deletable` and `delete_document` Tauri commands that validate retrieval ground truth references before allowing deletion
- Perform cascading delete in a transaction (image_chunk_retrieved_result → image_chunk → page_chunk_relation → page → document → file) with orphan file cleanup
- Add `DeleteDocumentDialog` component with 3 states: loading, blocked (lists blocking queries), and confirm (destructive action)
- Add hover-visible delete button on each document in the sidebar list

Closes #4

## Test plan

- [ ] Delete a document with no query references → should succeed after confirmation
- [ ] Attempt to delete a document whose pages are referenced in queries → should show blocked dialog listing the queries
- [ ] Verify the document list updates after deletion
- [ ] Verify current document view clears if the deleted doc was selected
- [ ] `cargo clippy` clean, `pnpm type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)